### PR TITLE
Add PM2 start script, TLS Nginx config, and deployment docs

### DIFF
--- a/deploy/nginx/e.logiszar.com.conf
+++ b/deploy/nginx/e.logiszar.com.conf
@@ -1,0 +1,31 @@
+server {
+    listen 80;
+    server_name e.logiszar.com;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    server_name e.logiszar.com;
+
+    ssl_certificate /etc/letsencrypt/live/e.logiszar.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/e.logiszar.com/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+}

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,42 @@
+# Despliegue
+
+## Requisitos
+- Node.js y npm
+- [PM2](https://pm2.keymetrics.io/) instalado globalmente (`npm install -g pm2`)
+- Nginx y Certbot
+
+## Pasos de despliegue
+1. **Acceso por SSH:** conectarse al VPS usando claves públicas.
+   ```bash
+   ssh usuario@e.logiszar.com
+   ```
+2. **Obtener código y dependencias:**
+   ```bash
+   git clone https://github.com/usuario/logiszar-erp.git /var/www/logiszar-erp
+   cd /var/www/logiszar-erp
+   npm ci
+   npm run build
+   ```
+3. **Iniciar con PM2:**
+   ```bash
+   npm run pm2
+   ```
+   El archivo [`ecosystem.config.js`](../ecosystem.config.js) define la aplicación.
+4. **Configurar Nginx con TLS:**
+   Copiar [`deploy/nginx/e.logiszar.com.conf`](../deploy/nginx/e.logiszar.com.conf) a `/etc/nginx/sites-available/` y habilitarlo.
+   Obtener certificados con Certbot:
+   ```bash
+   sudo certbot certonly --webroot -w /var/www/certbot -d e.logiszar.com
+   sudo systemctl reload nginx
+   ```
+
+## Rotación de credenciales
+1. Generar una nueva clave desde el cliente:
+   ```bash
+   ssh-keygen -t ed25519 -C "deploy@e.logiszar.com"
+   ```
+2. Copiar la clave pública al servidor y añadirla a `~/.ssh/authorized_keys` del usuario correspondiente.
+3. Eliminar claves antiguas del archivo `authorized_keys`.
+4. Reiniciar el servicio SSH si se modificó la configuración (`sudo systemctl restart ssh`).
+
+Mantener deshabilitado el acceso por contraseña (`PasswordAuthentication no`) en `/etc/ssh/sshd_config` para forzar el uso de claves.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start -p 3000",
-    "lint": "eslint"
+    "lint": "eslint",
+    "pm2": "pm2 start ecosystem.config.js && pm2 save"
   },
   "dependencies": {
     "next": "15.5.2",


### PR DESCRIPTION
## Summary
- add npm script to run PM2 using existing ecosystem.config.js
- provide Nginx config for e.logiszar.com with Let's Encrypt TLS
- document deployment process and credential rotation steps

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68be20dd41d88328a3ae15e177f991ca