### PR TITLE
feat: add prisma schema and scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "15.5.2",
         "react": "19.1.0",
-        "react-dom": "19.1.0"
+        "react-dom": "19.1.0",
+        "@prisma/client": "^5.15.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -21,7 +22,8 @@
         "eslint": "^9",
         "eslint-config-next": "15.5.2",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "typescript": "^5",
+        "prisma": "^5.15.0"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -6,12 +6,15 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start -p 3000",
-    "lint": "eslint"
+    "lint": "eslint",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev"
   },
   "dependencies": {
     "next": "15.5.2",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "@prisma/client": "^5.15.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -22,6 +25,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.5.2",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "prisma": "^5.15.0"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,153 @@
+datasource db {
+  provider = "mysql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+enum PaymentMethod {
+  CASH
+  CHEQUE
+  TRANSFER
+}
+
+enum DocumentStatus {
+  PENDING
+  COMPLETED
+  CANCELLED
+}
+
+enum ChequeStatus {
+  PENDING
+  CLEARED
+  BOUNCED
+}
+
+enum LedgerEntryType {
+  INVOICE
+  CREDIT_NOTE
+  DELIVERY_NOTE
+  PAYMENT
+  CHEQUE
+}
+
+model Customer {
+  id            Int             @id @default(autoincrement())
+  name          String
+  email         String?         @unique
+  phone         String?
+  createdAt     DateTime        @default(now())
+  updatedAt     DateTime        @updatedAt
+  invoices      Invoice[]
+  creditNotes   CreditNote[]
+  deliveryNotes DeliveryNote[]
+  payments      Payment[]
+  cheques       Cheque[]
+  ledgerEntries CustomerLedger[]
+}
+
+model Product {
+  id           Int             @id @default(autoincrement())
+  name         String
+  sku          String?         @unique
+  createdAt    DateTime        @default(now())
+  updatedAt    DateTime        @updatedAt
+  priceItems   PriceListItem[]
+  invoiceItems InvoiceItem[]
+}
+
+model PriceList {
+  id        Int             @id @default(autoincrement())
+  name      String
+  createdAt DateTime        @default(now())
+  updatedAt DateTime        @updatedAt
+  items     PriceListItem[]
+}
+
+model PriceListItem {
+  id          Int       @id @default(autoincrement())
+  price       Decimal   @db.Decimal(10, 2)
+  product     Product   @relation(fields: [productId], references: [id])
+  productId   Int
+  priceList   PriceList @relation(fields: [priceListId], references: [id])
+  priceListId Int
+}
+
+model Invoice {
+  id          Int          @id @default(autoincrement())
+  number      String       @unique
+  customer    Customer     @relation(fields: [customerId], references: [id])
+  customerId  Int
+  date        DateTime     @default(now())
+  status      DocumentStatus
+  items       InvoiceItem[]
+  payments    Payment[]
+  total       Decimal      @db.Decimal(10, 2)
+  creditNotes CreditNote[]
+}
+
+model InvoiceItem {
+  id        Int     @id @default(autoincrement())
+  invoice   Invoice @relation(fields: [invoiceId], references: [id])
+  invoiceId Int
+  product   Product @relation(fields: [productId], references: [id])
+  productId Int
+  quantity  Int
+  price     Decimal @db.Decimal(10, 2)
+}
+
+model CreditNote {
+  id         Int           @id @default(autoincrement())
+  number     String        @unique
+  customer   Customer      @relation(fields: [customerId], references: [id])
+  customerId Int
+  invoice    Invoice?      @relation(fields: [invoiceId], references: [id])
+  invoiceId  Int?
+  date       DateTime      @default(now())
+  status     DocumentStatus
+  amount     Decimal       @db.Decimal(10, 2)
+}
+
+model DeliveryNote {
+  id         Int           @id @default(autoincrement())
+  number     String        @unique
+  customer   Customer      @relation(fields: [customerId], references: [id])
+  customerId Int
+  date       DateTime      @default(now())
+  status     DocumentStatus
+}
+
+model Payment {
+  id         Int           @id @default(autoincrement())
+  customer   Customer      @relation(fields: [customerId], references: [id])
+  customerId Int
+  invoice    Invoice?      @relation(fields: [invoiceId], references: [id])
+  invoiceId  Int?
+  method     PaymentMethod
+  amount     Decimal       @db.Decimal(10, 2)
+  date       DateTime      @default(now())
+  cheque     Cheque?
+  status     DocumentStatus
+}
+
+model Cheque {
+  id        Int      @id @default(autoincrement())
+  number    String   @unique
+  bank      String
+  dueDate   DateTime
+  status    ChequeStatus
+  payment   Payment  @relation(fields: [paymentId], references: [id])
+  paymentId Int      @unique
+}
+
+model CustomerLedger {
+  id         Int            @id @default(autoincrement())
+  customer   Customer       @relation(fields: [customerId], references: [id])
+  customerId Int
+  entryType  LedgerEntryType
+  reference  String?
+  amount     Decimal        @db.Decimal(10, 2)
+  date       DateTime       @default(now())
+}


### PR DESCRIPTION
## Summary
- add Prisma models and enums for ERP domain
- configure MySQL datasource and client generator
- wire Prisma scripts and dependencies

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run prisma:generate` *(fails: prisma: not found)*
- `npm run prisma:migrate` *(fails: prisma: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68be20cf7adc8328bac536825eda9c6f