### PR TITLE
feat: add mailer utility with SMTP support

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "15.5.2",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "nodemailer": "^6.9.13"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/api/facturas/route.ts
+++ b/src/app/api/facturas/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { sendMail } from '@/lib/mailer';
+
+export async function POST(req: NextRequest) {
+  const { to, pdfBase64 } = await req.json();
+  const buffer = Buffer.from(pdfBase64, 'base64');
+
+  await sendMail({
+    to,
+    subject: 'Factura',
+    text: 'Adjunto PDF de la factura.',
+    attachments: [{ filename: 'factura.pdf', content: buffer }],
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/notas-de-credito/route.ts
+++ b/src/app/api/notas-de-credito/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { sendMail } from '@/lib/mailer';
+
+export async function POST(req: NextRequest) {
+  const { to, pdfBase64 } = await req.json();
+  const buffer = Buffer.from(pdfBase64, 'base64');
+
+  await sendMail({
+    to,
+    subject: 'Nota de crédito',
+    text: 'Adjunto PDF de la nota de crédito.',
+    attachments: [{ filename: 'nota-de-credito.pdf', content: buffer }],
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/remitos/route.ts
+++ b/src/app/api/remitos/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { sendMail } from '@/lib/mailer';
+
+export async function POST(req: NextRequest) {
+  const { to, pdfBase64 } = await req.json();
+  const buffer = Buffer.from(pdfBase64, 'base64');
+
+  await sendMail({
+    to,
+    subject: 'Remito',
+    text: 'Adjunto PDF del remito.',
+    attachments: [{ filename: 'remito.pdf', content: buffer }],
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/lib/mailer.ts
+++ b/src/lib/mailer.ts
@@ -1,0 +1,27 @@
+import nodemailer from 'nodemailer';
+
+const transporter = nodemailer.createTransport({
+  host: process.env.SMTP_HOST,
+  port: Number(process.env.SMTP_PORT) || 465,
+  secure: true,
+  auth: {
+    user: process.env.SMTP_USER,
+    pass: process.env.SMTP_PASS,
+  },
+});
+
+interface SendMailOptions {
+  to: string | string[];
+  subject: string;
+  text?: string;
+  html?: string;
+  attachments?: { filename: string; content: Buffer | string }[];
+}
+
+export async function sendMail(options: SendMailOptions) {
+  await transporter.sendMail({
+    from: process.env.SMTP_USER,
+    cc: 'administracion@logiszar.com',
+    ...options,
+  });
+}


### PR DESCRIPTION
## Summary
- install nodemailer dependency
- add reusable SMTP mailer with automatic admin CC
- send invoice, credit note, and remito PDFs via new API routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68be20da729c8328983aa04ccc91d975