### PR TITLE
docs: add env example and setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# Database configuration
+DATABASE_URL=
+
+# AFIP credentials
+AFIP_CERT_PATH=
+AFIP_KEY_PATH=
+AFIP_CUIT=
+AFIP_ENV=
+
+# SMTP configuration
+SMTP_HOST=
+SMTP_PORT=
+SMTP_USER=
+SMTP_PASS=
+SMTP_SECURE=
+
+# Application
+APP_BASE_URL=
+FX_SOURCE=

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .next/
 node_modules/
 .env*
+!.env.example
 *.log

--- a/README.md
+++ b/README.md
@@ -1,4 +1,27 @@
+# Logiszar ERP
+
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+
+## Configuración del entorno
+
+1. Copia `.env.example` a `.env`:
+
+```bash
+cp .env.example .env
+```
+
+2. Completa las variables necesarias en el archivo `.env`:
+
+- `DATABASE_URL`: cadena de conexión de la base de datos.
+- `AFIP_CERT_PATH`: ruta al certificado `.crt` provisto por AFIP.
+- `AFIP_KEY_PATH`: ruta a la clave privada `.key` asociada al certificado.
+- `AFIP_CUIT`: CUIT de la empresa.
+- `AFIP_ENV`: entorno de AFIP (`test` o `prod`).
+- `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `SMTP_SECURE`: configuración del servidor de correo.
+- `APP_BASE_URL`: URL base de la aplicación.
+- `FX_SOURCE`: fuente para obtener tipos de cambio.
+
+Las rutas de `AFIP_CERT_PATH` y `AFIP_KEY_PATH` deben apuntar a los archivos generados para el CUIT correspondiente.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholders for database, AFIP, SMTP and app settings
- document environment configuration steps in README
- track `.env.example` by unignoring it in `.gitignore`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68be20dcf1c48328a984dbdfdacece08